### PR TITLE
Fix: Remove non-standard 'name' field from function_call_output

### DIFF
--- a/hermitclaw/brain.py
+++ b/hermitclaw/brain.py
@@ -758,7 +758,6 @@ class Brain:
                     {
                         "type": "function_call_output",
                         "call_id": call_id,
-                        "name": tool_name,
                         "output": result,
                     }
                 )


### PR DESCRIPTION
## Summary

Removes the non-standard `name` field from the `function_call_output` dict in `brain.py`.

## Problem

The OpenAI Chat Completions API tool message format only expects `role`, `content`, and `tool_call_id`. The extra `name` field was causing some LLM providers to reject follow-up requests.

## Fix

Removed the `"name": tool_name` line from the function_call_output dict.

Fixes #1

Related: brendanhogan/hermitclaw#10